### PR TITLE
Optimize single-field sort keys to avoid strings.Builder

### DIFF
--- a/example/v1/example.pb.dynamo.go
+++ b/example/v1/example.pb.dynamo.go
@@ -568,10 +568,7 @@ func UserPartitionKeyWithoutShard(tenantId string) string {
 }
 
 func (p *User) SortKey() string {
-	var sb strings.Builder
-	sb.Reset()
-	_, _ = sb.WriteString(p.GetId())
-	return sb.String()
+	return p.GetId()
 }
 
 func UserSortKey(id *string) string {
@@ -591,10 +588,7 @@ func UserGsi1PkKey(tenantId *string) string {
 }
 
 func (p *User) Gsi1SkKey() string {
-	var sb strings.Builder
-	sb.Reset()
-	_, _ = sb.WriteString(p.GetIdpId())
-	return sb.String()
+	return p.GetIdpId()
 }
 
 func UserGsi1SkKey(idpId *string) string {
@@ -733,10 +727,7 @@ func UserV2PartitionKey(tenantId *string) string {
 }
 
 func (p *UserV2) SortKey() string {
-	var sb strings.Builder
-	sb.Reset()
-	_, _ = sb.WriteString(p.GetId())
-	return sb.String()
+	return p.GetId()
 }
 
 func UserV2SortKey(id *string) string {
@@ -844,10 +835,7 @@ func UserV2Gsi2PkKeyWithoutShard(tenantId string, idpId string) string {
 }
 
 func (p *UserV2) Gsi2SkKey() string {
-	var sb strings.Builder
-	sb.Reset()
-	_, _ = sb.WriteString(strconv.FormatInt(int64(p.GetAnEnum()), 10))
-	return sb.String()
+	return strconv.FormatInt(int64(p.GetAnEnum()), 10)
 }
 
 func UserV2Gsi2SkKey(anEnum *BasicEnum) string {

--- a/internal/pgd/module.go
+++ b/internal/pgd/module.go
@@ -347,6 +347,24 @@ func (m *Module) applyKeyFuncs(f *jen.File, in pgs.File) error {
 				stmts = append(stmts,
 					jen.Return(jen.Lit(key.constant)),
 				)
+			} else if !key.prefix && len(key.fields) == 1 {
+				// Optimization: for sort keys with a single field, avoid strings.Builder overhead
+				field := fieldByName(msg, key.fields[0])
+				pt := field.Type().ProtoType()
+				srcName := field.Name().UpperCamelCase().String()
+				srcFunc := jen.Id("p").Dot("Get" + srcName).Call()
+
+				switch {
+				case pt == pgs.StringT:
+					// Single string field: return directly without strings.Builder
+					stmts = append(stmts, jen.Return(srcFunc))
+				case pt.IsNumeric() || pt == pgs.EnumT:
+					// Single numeric/enum field: format and return directly
+					fmtCall := numberFormatStatement(pt, srcFunc)
+					stmts = append(stmts, jen.Return(fmtCall))
+				default:
+					panic(fmt.Sprintf("Single field key: unsupported type: %s", pt.String()))
+				}
 			} else {
 				stmts = append(stmts,
 					jen.Op("var").Id("sb").Qual(stringsPkg, "Builder"),


### PR DESCRIPTION
## Summary

For sort keys with a single string or numeric field, generate a direct return statement instead of using `strings.Builder`. This eliminates unnecessary allocations for the common case of single-field keys.

### Before
```go
func (p *User) Gsi1SkKey() string {
    var sb strings.Builder
    sb.Reset()
    _, _ = sb.WriteString(p.GetEmail())
    return sb.String()
}
```

### After
```go
func (p *User) Gsi1SkKey() string {
    return p.GetEmail()
}
```

## Motivation

In production profiling of a high-throughput DynamoDB workload, this pattern was identified as contributing ~2.3% of heap allocations (701MB over 80 seconds). The `strings.Builder` creates unnecessary allocations when the key is just a single field that can be returned directly.

The optimization applies to:
- Single string field sort keys: returns `p.GetFieldName()` directly
- Single numeric/enum field sort keys: returns the formatted value directly

Multi-field keys and partition keys (which include a prefix) continue to use `strings.Builder` as before.

## Test plan

- [x] Regenerated example protos - verified optimized code is generated
- [x] All existing tests pass
- [x] Manual inspection of generated code confirms correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)